### PR TITLE
Ability to define the target element instead of document.body

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To enable image annotation in your project follow these 3 simple steps:
 ```js
 import { MarkerArea } from 'markerjs';
 
-const m = new MarkerArea(document.getElementById('imageToAnnotate'));
+const m = new MarkerArea(document.getElementById('imageToAnnotate'), document.getElementById('targetElement'));
 m.show(
     (dataUrl) => {
         const res = document.getElementById("resultImage");
@@ -40,7 +40,7 @@ marker.js has you covered. Instead of calling `MarkerArea.show()` like described
     - `ArrowMarker` - arrows, 
     - `CoverMarker` - solid rectangle to cover areas you'd rather not show,
     - `HighlightMarker` - semi-transparent rectangle to highlight areas,
-    - `LineMaker` - lines,
+    - `LineMarker` - lines,
     - `RectMarker` - transparent rectangle with solid border,
     - `TextMarker` - text;
 - `deleteActiveMarker()` - deletes currently selected marker (if any);
@@ -78,7 +78,7 @@ So, our JavaScript code would look something like this:
 let markerArea;
 
 function showApiMarker(img) {
-    markerArea = new markerjs.MarkerArea(img);
+    markerArea = new markerjs.MarkerArea(img, document.getElementById('targetElement'));
     markerArea.open();
     document.getElementById('markerActivator').style.display = 'none';
     document.getElementById('markerControls').style.display = '';
@@ -97,7 +97,7 @@ function deleteMarker() {
 function render() {
     if (markerArea) {
         markerArea.render((dataUrl) => {
-            const res = document.getElementById("resultImage");
+            const res = document.getElementById('resultImage', document.getElementById('targetElement'));
             res.src = dataUrl;
             res.style.display = "";
         });

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ function deleteMarker() {
 function render() {
     if (markerArea) {
         markerArea.render((dataUrl) => {
-            const res = document.getElementById('resultImage', document.getElementById('targetElement'));
+            const res = document.getElementById('resultImage');
             res.src = dataUrl;
             res.style.display = "";
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "markerjs",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markerjs",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Annotate and mark images",
   "main": "markerjs.umd.js",
   "module": "markerjs.esm.js",

--- a/src/MarkerArea.ts
+++ b/src/MarkerArea.ts
@@ -21,6 +21,7 @@ import CloseIcon from "./assets/core-toolbar-icons/times.svg";
 import Logo from "./assets/markerjs-logo-m.svg";
 
 export class MarkerArea {
+    private targetDom: HTMLBodyElement;
     private target: HTMLImageElement;
     private markerImage: SVGSVGElement;
     private markerImageHolder: HTMLDivElement;
@@ -80,8 +81,9 @@ export class MarkerArea {
 
     private scale = 1.0;
 
-    constructor(target: HTMLImageElement) {
+    constructor(target: HTMLImageElement, targetDom: HTMLBodyElement) {
         this.target = target;
+        this.targetDom = targetDom;
         this.width = target.clientWidth;
         this.height = target.clientHeight;
 
@@ -121,13 +123,13 @@ export class MarkerArea {
 
     public close = () => {
         if (this.toolbarUI) {
-            document.body.removeChild(this.toolbarUI);
+            this.targetDom.removeChild(this.toolbarUI);
         }
         if (this.markerImage) {
-            document.body.removeChild(this.markerImageHolder);
+            this.targetDom.removeChild(this.markerImageHolder);
         }
         if (this.logoUI) {
-            document.body.removeChild(this.logoUI);
+            this.targetDom.removeChild(this.logoUI);
         }
     }
 
@@ -165,7 +167,7 @@ export class MarkerArea {
 
     private setTargetRect = () => {
         const targetRect = this.target.getBoundingClientRect() as DOMRect;
-        const bodyRect = document.body.parentElement.getBoundingClientRect();
+        const bodyRect = this.targetDom.parentElement.getBoundingClientRect();
         this.targetRect = { left: (targetRect.left - bodyRect.left),
             top: (targetRect.top - bodyRect.top) } as ClientRect;
 
@@ -226,7 +228,7 @@ export class MarkerArea {
 
         this.markerImageHolder.appendChild(this.markerImage);
 
-        document.body.appendChild(this.markerImageHolder);
+        this.targetDom.appendChild(this.markerImageHolder);
     }
 
     private adjustUI = (ev: UIEvent) => {
@@ -272,7 +274,7 @@ export class MarkerArea {
     private showUI = () => {
         this.toolbar = new Toolbar(this.toolbars, this.toolbarClick);
         this.toolbarUI = this.toolbar.getUI();
-        document.body.appendChild(this.toolbarUI);
+        this.targetDom.appendChild(this.toolbarUI);
         this.toolbarUI.style.position = "absolute";
         this.positionToolbar();
     }
@@ -416,7 +418,7 @@ export class MarkerArea {
 
         this.logoUI.appendChild(link);
 
-        document.body.appendChild(this.logoUI);
+        this.targetDom.appendChild(this.logoUI);
 
         this.logoUI.style.position = "absolute";
         this.positionLogo();


### PR DESCRIPTION
Thank you for this awesome library.

I added the ability to define the target element instead of document.body only, so now this also works in modals or other scenarios where you need it not on the document.body